### PR TITLE
Add requirements.txt and instructions for enum4linux-ng

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,10 @@ This allows for an automated and consistent assessment of specific services (i.e
 Install the required tools:
 
 ```sh
-sudo apt install curl dnsutils enum4linux-ng feroxbuster nikto nmap onesixtyone seclists smbclient snmp sslyze testssl.sh whatweb
-pip3 install defusedxml rich toml
+git clone https://github.com/cddmp/enum4linux-ng.git; cd enum4linux-ng; sudo
+python3 setup.py install
+sudo apt install curl dnsutils feroxbuster nikto nmap onesixtyone seclists smbclient snmp sslyze testssl.sh whatweb
+pip3 install -r requirements.txt
 ```
 
 Install the tool suite:
@@ -36,7 +38,7 @@ ln -s $(realpath icke.sh) ~/bin/icke
 ln -s $(realpath recon.py) ~/bin/recon
 ```
 
-## usage 
+## usage
 
 ```txt
 $ recon -h

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+defusedxml
+rich
+toml


### PR DESCRIPTION
This commit adds a requirements.txt file which might ease some setup steps.

In addition it adds some instructions for enum4linux-ng setup. Running the current instructions failes, as enum4linux-ng is unfortunately still not in the Kali Linux repository.

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>