### PR TITLE
Add --warning batch flag to testssl

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -176,7 +176,7 @@ patterns = [ '^smb', '^microsoft\-ds', '^netbios' ]
   [smb.scans.smbclient]
   command = 'smbclient --list={address} --no-pass --command="recurse ON; ls" 2>&1 | tee {result_file}'
   run_once = true
-  
+
   [smb.scans.'enum4linux-ng']
   command = 'NO_COLOR=yes; enum4linux-ng.py -As -oA {result_file} {address}'
   run_once = true
@@ -218,7 +218,7 @@ patterns = [ '^telnet' ]
 patterns = [ 'https', '^ssl\|', '^tls\|' ]
 
   [tls.scans.testssl]
-  command = '#testssl --nodns min --mapping iana --color 0 {hostname}:{port} 2>&1 | tee "{result_file}"'
+  command = '#testssl --nodns min --mapping iana --color 0 --warnings batch {hostname}:{port} 2>&1 | tee "{result_file}"'
 
   [tls.scans.sslscan]
   command = '#sslscan --show-certificate --no-colour {hostname}:{port} 2>&1 | tee "{result_file}"'


### PR DESCRIPTION
This flag allows testssl to cancel on error.
This might be useful if a port is detected as TLS by nmap, without actually providing an TLS/SSL enabled server.
Without this flag testssl will wait for the user to enter confirm, that the scan should continue, even without a TLS/SSL enabled server.

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>