### PR TITLE
analyzer: Add check if files exist in input directory

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -70,6 +70,9 @@ def process(args):
   files = get_files(args.input, args.service)
   #print(json.dumps(files, indent=2))
 
+  if not files:
+      sys.exit(f"there are no files to analyze for {args.service} in {args.input}")
+
   services = {}
 
   module = importlib.import_module(f'analyzers.{args.service}')


### PR DESCRIPTION
If there are no relevant files for the requested service in the input directory, the analyzer will throw a KeyError Exception which isn't very helpful to understand why the tool fails. Instead the analyzer will return gracefully.