### PR TITLE
[nas]: add JSON parsing exception handling

### DIFF
--- a/analyzers/tls/testssl.py
+++ b/analyzers/tls/testssl.py
@@ -38,7 +38,11 @@ class Parser(AbstractParser):
     super().parse_file(path)
 
     with open(path, 'r') as f:
-      results = json.load(f)
+      try:
+        results = json.load(f)
+      except json.decoder.JSONDecodeError as e:
+          print(f"Error in reading file {path}: {e}")
+          return
 
     for f in filter(lambda x: x['id'] == 'optimal_proto', results):
       if "doesn't seem to be a TLS/SSL enabled server" in f['finding']:


### PR DESCRIPTION
On some occasions testssl can create non valid json files. This causes the parser to fail (rightfully) and the analyze command to abort with an exception.