### PR TITLE
config: Add nmap_option parameter

### DIFF
--- a/config/scans.toml
+++ b/config/scans.toml
@@ -4,6 +4,7 @@
 domain = "example.com"
 username = "user"
 password = "password"
+nmap_option = "-T3"
 
 # documentation on the Nmap Script Engine:
 # https://nmap.org/nsedoc/
@@ -103,13 +104,13 @@ patterns = [ 'isakmp' ]
   command = '"{PATH_TO_SCANNERS}/ike.py" {address} --port {port} | tee "{result_file}.log"'
 
   [isakmp.scans.nmap]
-  command = 'nmap -sU -Pn -sV -p {port} --script="banner,ike-version" -oN "{result_file}.log" {address}'
+  command = 'nmap -sU {nmap_option} -Pn -sV -p {port} --script="banner,ike-version" -oN "{result_file}.log" {address}'
 
 [kerberos]
 patterns = [ 'kerberos', 'kpasswd' ]
 
   [kerberos.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,krb5-enum-users" -oN "{result_file}.log" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,krb5-enum-users" -oN "{result_file}.log" {address}'
 
 [ldap]
 patterns = [ 'ldap' ]
@@ -148,7 +149,7 @@ patterns = [ '^nntp', 'snews' ]
 patterns = [ '^ntp' ]
 
   [ntp.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,ntp-info,ntp-monlist" -oN "{result_file}.log" -oX "{result_file}.xml" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,ntp-info,ntp-monlist" -oN "{result_file}.log" -oX "{result_file}.xml" {address}'
 
   [ntp.scans.ntp]
   command = '"{PATH_TO_SCANNERS}/ntp.py" --port {port} --json "{result_file}.json" {address} 2>&1 | tee "{result_file}.log"'
@@ -169,7 +170,7 @@ patterns = [ 'pop3' ]
 patterns = [ 'ms-wbt-server' ]
 
   [rdp.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,rdp* and not (brute or broadcast or dos or external or fuzzer)" -oX "{result_file}.xml" -oN "{result_file}.log" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,rdp* and not (brute or broadcast or dos or external or fuzzer)" -oX "{result_file}.xml" -oN "{result_file}.log" {address}'
 
 [rmi]
 patterns = [ 'rmiregistry' ]
@@ -205,7 +206,7 @@ patterns = [ 'smb', 'microsoft-ds', 'netbios' ]
   # SMB does not support TLS/STARTTLS; only LDAP can use TLS: https://wiki.samba.org/index.php/Configuring_LDAP_over_SSL_(LDAPS)_on_a_Samba_AD_DC
 
   [smb.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,(nbstat or smb*) and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,(nbstat or smb*) and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" {address}'
 
   [smb.scans.smbclient]
   command = 'smbclient --list={address} --no-pass --command="recurse ON; ls" 2>&1 | tee "{result_file}.log"'
@@ -228,7 +229,7 @@ patterns = [ 'smtp' ]
 patterns = [ 'snmp' ]
 
   [snmp.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,snmp* and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,snmp* and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" {address}'
 
   [snmp.scans.onesixtyone]
   command = '#onesixtyone -c /usr/share/seclists/Discovery/SNMP/common-snmp-community-strings-onesixtyone.txt -dd {address} 2>&1 | tee "{result_file}.log"'
@@ -270,7 +271,7 @@ patterns = [
 ]
 
   [tls.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,ssl* and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" -oX "{result_file}.xml" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,ssl* and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" -oX "{result_file}.xml" {address}'
 
   [tls.scans.sslscan]
   command = '#sslscan --show-certificate --ocsp --show-sigs --xml="{result_file}.xml" {hostname}:{port} 2>&1 | tee "{result_file}.log"'
@@ -301,7 +302,7 @@ patterns = [
 ]
 
   [tls_misc.scans.nmap]
-  command = 'nmap -sT -sU -Pn -sV -p {port} --script="banner,ssl* and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" -oX "{result_file}.xml" {address}'
+  command = 'nmap -sT -sU {nmap_option} -Pn -sV -p {port} --script="banner,ssl* and not (brute or broadcast or dos or external or fuzzer)" -oN "{result_file}.log" -oX "{result_file}.xml" {address}'
 
   [tls_misc.scans.sslscan]
   command = '#echo "ftp imap irc ldap pop3 smtp mysql xmpp" | grep --quiet "{application_protocol}" && sslscan --show-certificate --show-sigs --starttls-$(echo {application_protocol} | sed -E "s:irc.*:irc:") --xml="{result_file}.xml" {address}:{port} 2>&1 | tee "{result_file}.log"'


### PR DESCRIPTION
Add a parameter to set additional options for nmap, especially on UDP scans. My idea is to speed up scans that might have no UDP ports open like on smb scans.
`-T3` is the default option and doesn't change anything therefore it was choosen. On the otherhand this will use 10 retries and has a `max-rtt-timeout` value of 10 seconds based on
https://nmap.org/book/performance-timing-templates.html. This means a scans with many many closed UDP ports might take a long time before they finish.