### PR TITLE
Add BSI recommendations as TLS analyzer config profile

### DIFF
--- a/config/recommendations/tls/bsi.toml
+++ b/config/recommendations/tls/bsi.toml
@@ -1,0 +1,108 @@
+# https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=6
+protocol_versions = [ "TLS 1.2", "TLS 1.3" ]
+
+preference = "client"
+
+# please be aware that BSI recommends AES-CBC mode only in conjunction with use of "Encrypt-then-MAC"
+cipher_suites = [
+  "TLS_AES_128_GCM_SHA256",
+  "TLS_AES_128_CCM_SHA256",
+  "TLS_AES_256_GCM_SHA384",
+  "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+  "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+  "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+  "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+  "TLS_ECDHE_ECDSA_WITH_AES_128_CCM",
+  "TLS_ECDHE_ECDSA_WITH_AES_256_CCM",
+  "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+  "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+  "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+  "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+  "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+  "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+  "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
+  "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
+  "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+  "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+  "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+  "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+  "TLS_DHE_RSA_WITH_AES_128_CCM",
+  "TLS_DHE_RSA_WITH_AES_256_CCM",
+  "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+  "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+  "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+  "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+  "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+  "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+  "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+  "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+  "TLS_DH_DSS_WITH_AES_128_CBC_SHA256",
+  "TLS_DH_DSS_WITH_AES_256_CBC_SHA256",
+  "TLS_DH_DSS_WITH_AES_128_GCM_SHA256",
+  "TLS_DH_DSS_WITH_AES_256_GCM_SHA384",
+  "TLS_DH_RSA_WITH_AES_128_CBC_SHA256",
+  "TLS_DH_RSA_WITH_AES_256_CBC_SHA256",
+  "TLS_DH_RSA_WITH_AES_128_GCM_SHA256",
+  "TLS_DH_RSA_WITH_AES_256_GCM_SHA384",
+  "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256",
+  "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384",
+  "TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256",
+  "TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384",
+  "TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256",
+  "TLS_DHE_PSK_WITH_AES_128_CBC_SHA256",
+  "TLS_DHE_PSK_WITH_AES_256_CBC_SHA384",
+  "TLS_DHE_PSK_WITH_AES_128_GCM_SHA256",
+  "TLS_DHE_PSK_WITH_AES_256_GCM_SHA384",
+  "TLS_DHE_PSK_WITH_AES_128_CCM",
+  "TLS_DHE_PSK_WITH_AES_256_CCM",
+  "TLS_RSA_PSK_WITH_AES_128_CBC_SHA256",
+  "TLS_RSA_PSK_WITH_AES_256_CBC_SHA384",
+  "TLS_RSA_PSK_WITH_AES_128_GCM_SHA256",
+  "TLS_RSA_PSK_WITH_AES_256_GCM_SHA384"
+]
+
+[key_exchange]
+methods = { RSA = 3000, DSA = 3000, ECDSA = 250, ECDH = 250, DH = 3000 }
+# some versions of OpenSSL report a key length of 253 bits for Ed25519 keys (instead of the correct 256 bits).
+# see https://github.com/openssl/openssl/issues/19070 regarding key length of Ed25519
+# therefore, we use the BSI recommendation of "at least 250 bits"
+
+groups = [ "brainpoolP256r1", "brainpoolP384r1", "brainpoolP512r1", "brainpoolP256r1tls13", "brainpoolP384r1tls13", "brainpoolP512r1tls13", "ffdhe3072", "ffdhe4096", "secp256r1", "secp384r1", "secp521r1" ]
+
+[extensions]
+yes = [
+  "encrypt_then_mac",		#TLS1.2 only and in conjunction with AES-CBC
+  "extended_master_secret"	#TLS1.2 only
+]
+
+no = [
+	"truncated_hmac",		#TLS1.2 only
+	"heartbeat_request",
+	"heartbeat_response"
+]
+
+[certificate]
+
+signature_algorithms = [
+  "rsa_pkcs1_sha256",
+  "rsa_pkcs1_sha384",
+  "rsa_pkcs1_sha512",
+  "rsa_pss_rsae_sha256",
+  "rsa_pss_rsae_sha384",
+  "rsa_pss_rsae_sha512",
+  "rsa_pss_pss_sha256",
+  "rsa_pss_pss_sha384",
+  "rsa_pss_pss_sha512",
+  "ecdsa_secp256r1_sha256",
+  "ecdsa_secp384r1_sha384",
+  "ecdsa_secp521r1_sha512",
+  "ecdsa_brainpoolP256r1tls13_sha256",
+  "ecdsa_brainpoolP384r1tls13_sha384",
+  "ecdsa_brainpoolP512r1tls13_sha512"
+]
+
+lifespan = 366
+
+  [certificate.public_key]
+  types = { RSA = 3000, DSA = 3000, ECDSA = 250, ECDH = 250, DH = 3000 }
+  curves = [ "brainpoolP256r1", "brainpoolP384r1", "brainpoolP512r1", "secp256r1", "secp384r1", "secp521r1" ]


### PR DESCRIPTION
Add TLS recommendations by [BSI-TR-02102-2](https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=6)