### PR TITLE
Analyzer: fix report-uri Key Error

### DIFF
--- a/config/issues/http/de.toml
+++ b/config/issues/http/de.toml
@@ -54,7 +54,7 @@ references = [
   "[Mozilla: HTTP headers: `content-security-policy`](https://developer.mozilla.org/en-US/docs/web/http/headers/content-security-policy)",
 ]
 
-["CSP report-uri deprecated"]
+["CSP `report-uri` deprecated"]
 description = "`content-security-policy`: `report-uri`-Richtlinie ist veraltet"
 recommendations = [ "`content-security-policy`: verwenden Sie `report-to` anstatt `report-uri`" ]
 references = [

--- a/config/issues/http/en.toml
+++ b/config/issues/http/en.toml
@@ -54,7 +54,7 @@ references = [
   "[Mozilla: HTTP headers: `content-security-policy`](https://developer.mozilla.org/en-US/docs/web/http/headers/content-security-policy)",
 ]
 
-["CSP report-uri deprecated"]
+["CSP `report-uri` deprecated"]
 description = "`content-security-policy`: `report-uri` directive is deprecated"
 recommendations = [ "`content-security-policy`: use `report-to` directive instead of `report-uri`" ]
 references = [


### PR DESCRIPTION
Add '`' around report-uri to fix a KeyError during template lookup in http analyzer.