### PR TITLE
Fix import errors on importerror

### DIFF
--- a/analyzers/dns/nmap.py
+++ b/analyzers/dns/nmap.py
@@ -1,10 +1,10 @@
 import copy
-import re
 
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
+  import sys
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import AbstractParser

--- a/analyzers/ftp/nmap.py
+++ b/analyzers/ftp/nmap.py
@@ -1,10 +1,10 @@
 import copy
-import re
 
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
+  import sys
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import Issue, AbstractParser

--- a/analyzers/http/nmap.py
+++ b/analyzers/http/nmap.py
@@ -1,11 +1,11 @@
 import copy
-import logging
 import re
 
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
+  import sys
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import AbstractParser

--- a/analyzers/ntp/nmap.py
+++ b/analyzers/ntp/nmap.py
@@ -4,7 +4,8 @@ import re
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
+  import sys
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import Issue, AbstractParser

--- a/analyzers/rdp/nmap.py
+++ b/analyzers/rdp/nmap.py
@@ -4,7 +4,8 @@ import re
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
+  import sys
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import Issue, AbstractParser

--- a/analyzers/ssh/nmap.py
+++ b/analyzers/ssh/nmap.py
@@ -4,7 +4,8 @@ import re
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
+  import sys
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import Issue, AbstractParser

--- a/analyzers/tls/nmap.py
+++ b/analyzers/tls/nmap.py
@@ -5,7 +5,7 @@ import sys
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import AbstractParser

--- a/analyzers/tls/sslscan.py
+++ b/analyzers/tls/sslscan.py
@@ -1,12 +1,11 @@
 import copy
 import datetime
-import re
 import sys
 
 try:
   # https://github.com/tiran/defusedxml
   import defusedxml.ElementTree
-except:
+except ImportError:
   sys.exit("this script requires the 'defusedxml' module.\nplease install it via 'pip3 install defusedxml'.")
 
 from .. import Issue, AbstractParser

--- a/analyzers/tls/sslyze.py
+++ b/analyzers/tls/sslyze.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import re
 
 from .. import Issue, AbstractParser
 from . import CERTIFICATE_SCHEMA, SERVICE_SCHEMA


### PR DESCRIPTION
In most nmap.py files the error message on import errors is not correctly displayed because sys is not imported.

I have also added the correct exception class to not catch unrelated errors.