### PR TITLE
Fix errorhandling in analyzer on corrupt files

### DIFF
--- a/analyzers/__init__.py
+++ b/analyzers/__init__.py
@@ -79,8 +79,8 @@ class AbstractParser:
     for path in files[self.file_type]:
       try:
         self.parse_file(path)
-      except error as e:
-        self.__class__.logger.warning("could not parse file!")
+      except Exception as e:
+        self.__class__.logger.warning(f"could not parse file: {e}")
 
     return self.services
 


### PR DESCRIPTION
The errorhandling was throwing Errors, as error is not a defined Exception. Also add a little information.