### PR TITLE
add typst template for easier typst formatting

### DIFF
--- a/config/templates/default.de.typ
+++ b/config/templates/default.de.typ
@@ -1,0 +1,47 @@
+= evidenz
+
+Die folgenden Hosts wurden analysiert:
+
+{% for asset in services.keys() %}
+- `{{ asset }}`
+{% endfor %}
+
+Die folgenden Schwachstellen und/oder Abweichungen von den empfohlenen Einstellungen (`{{recommendations_file}}`) wurden identifiziert:
+{% for asset, issues in affected_assets.items() %}
+
+== {{ asset }}
+
+{% for issue in issues %}
+- {{ issue }}
+{% endfor %}
+{% endfor %}
+
+= betroffene assets
+
+{% for asset in affected_assets.keys() %}
+- `{{ asset }}`
+{% endfor %}
+{% if recommendations|length %}
+
+= empfehlungen
+
+{% for recommendation in recommendations %}
+- {{ recommendation }}
+{% endfor %}
+{% endif %}
+{% if references|length %}
+
+= zusätzliche informationen
+
+{% for reference in references %}
+- {{ reference }}
+{% endfor %}
+{% endif %}
+{% if additional_info|length %}
+
+= additional info
+
+{% for info in additional_info %}
+- {{ info }}
+{% endfor %}
+{% endif %}

--- a/config/templates/default.en.typ
+++ b/config/templates/default.en.typ
@@ -1,0 +1,47 @@
+= evidence
+
+The following hosts have been analyzed:
+
+{% for asset in services.keys() %}
+- `{{ asset }}`
+{% endfor %}
+
+The following vulnerabilities and/or deviations from the recommended settings (`{{recommendations_file}}`) have been identified:
+{% for asset, issues in affected_assets.items() %}
+
+== {{ asset }}
+
+{% for issue in issues %}
+- {{ issue }}
+{% endfor %}
+{% endfor %}
+
+= affected assets
+
+{% for asset in affected_assets.keys() %}
+- `{{ asset }}`
+{% endfor %}
+{% if recommendations|length %}
+
+= recommendations
+
+{% for recommendation in recommendations %}
+- {{ recommendation }}
+{% endfor %}
+{% endif %}
+{% if references|length %}
+
+= references
+
+{% for reference in references %}
+- {{ reference }}
+{% endfor %}
+{% endif %}
+{% if additional_info|length %}
+
+= additional info
+
+{% for info in additional_info %}
+- {{ info }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
A cut down version of #106 relating to #105.
This is intended to simplify the workflow of generating multiple typst reports, thus removing the need for the additional pandoc step for each file.