### PR TITLE
Fix enum4linux-ng ad analyzer behaviour

### DIFF
--- a/analyzers/smb/__init__.py
+++ b/analyzers/smb/__init__.py
@@ -282,6 +282,8 @@ class Analyzer(AbstractAnalyzer):
     for field_name, field_value in domain_info.items():
       if field_name not in recommendations['AD']['domain']:
         continue
+ 
+      field_value = 0 if field_value == 'None' else field_value
 
       recommendation = recommendations['AD']['domain'][field_name]
 


### PR DESCRIPTION
the enum4linux-ng ad analyzer will fail if the field_value ist 'None' as in the str type meaning, not the None-type